### PR TITLE
modified cloudy.CreateCompleteEnvironment args for new env interface

### DIFF
--- a/group_test.go
+++ b/group_test.go
@@ -11,7 +11,7 @@ import (
 func TestGroupManager(t *testing.T) {
 	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
 
-	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
 	cloudy.SetDefaultEnvironment(env)
 
 	ctx := cloudy.StartContext()
@@ -44,7 +44,7 @@ func TestListGroups(t *testing.T) {
 
 	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
 
-	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
 	cloudy.SetDefaultEnvironment(env)
 
 	ctx := cloudy.StartContext()

--- a/licenses.go
+++ b/licenses.go
@@ -74,6 +74,8 @@ func (lm *MsGraphLicenseManager) AssignLicense(ctx context.Context, userId strin
 	return err
 }
 
+// TODO
+// Inherited license assignments cannot be removed from the user directly. To remove their license, you must remove them from their group.
 func (lm *MsGraphLicenseManager) RemoveLicense(ctx context.Context, userId string, licenseSkus ...string) error {
 	body := users.NewItemAssignLicensePostRequestBody()
 

--- a/licenses_test.go
+++ b/licenses_test.go
@@ -11,7 +11,7 @@ import (
 func TestLicenseManager(t *testing.T) {
 	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
 
-	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
 	cloudy.SetDefaultEnvironment(env)
 
 	ctx := cloudy.StartContext()

--- a/user_test.go
+++ b/user_test.go
@@ -16,7 +16,7 @@ import (
 func TestUserManager(t *testing.T) {
 	_ = testutil.LoadEnv("../arkloud-conf/arkloud.env")
 
-	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "")
+	env := cloudy.CreateCompleteEnvironment("ARKLOUD_ENV", "USERAPI_PREFIX", "KEYVAULT")
 	cloudy.SetDefaultEnvironment(env)
 
 	ctx := cloudy.StartContext()


### PR DESCRIPTION
#### What does this PR do?

Modifies the test environment to use the new env heirarchy

Also adds a comment to the license.go to indicate that users may not be removed from licenses that the receive based on their user group.


Note: the when running tests group_test:TestGroupManager the enviroemnt appears to eb sucessfully constructed, but the test itself seg faults.   

##### Who is reviewing it?
 @dyerz 
 
##### How should this be tested?
This PR requires the cloudy master branch  from 15 Mar 2023

Create an arkloud.env file located in the arkcloud/arkloud-conf dir

The file should have the following properties with appropriate values. 

```
KEYVAULT_AZ_CLIENT_SECRET=
KEYVAULT_AZ_CLIENT_ID=
KEYVAULT_AZ_TENANT_ID=
AZ_VAULT_URL=
ARKLOUD_ENV=
USERAPI_PREFIX=

DATATYPE_USER=
DATATYPE_PASSWORD=
DATATYPE_HOST=
DATATYPE_DATABASE=

TEST_USER=Bubba@collider.onmicrosoft.us
TEST_SKU= <SKU for office 365 goes here>

```

